### PR TITLE
Add getChannelValue and getEEPROMValue accessor methods.

### DIFF
--- a/Adafruit_MCP4728.cpp
+++ b/Adafruit_MCP4728.cpp
@@ -180,3 +180,43 @@ bool Adafruit_MCP4728::saveToEEPROM(void) {
   delay(15);
   return true;
 }
+
+/**
+ * @brief Read the current value of one DAC value.
+ *
+ * @param channel the channel to read
+ * @return current value of the specified channel
+ */
+
+uint16_t Adafruit_MCP4728::getChannelValue(MCP4728_channel_t channel) {
+  uint16_t value;
+  uint8_t input_buffer[24];
+  /* 24 bytes are (3 bytes outreg, 3 bytes EEPROM) x 4 channels */
+  uint8_t reg_base = 6 * ((uint8_t)channel);
+
+  i2c_dev->read(input_buffer, 24);
+  value =
+      input_buffer[reg_base + 2] + ((0x0F & input_buffer[reg_base + 1]) << 8);
+
+  return value;
+}
+
+/**
+ * @brief Read the current value of one EEPROM value.
+ *
+ * @param channel the channel to read
+ * @return current value of the specified channel
+ */
+
+uint16_t Adafruit_MCP4728::getEEPROMValue(MCP4728_channel_t channel) {
+  uint16_t value;
+  uint8_t input_buffer[24];
+  /* 24 bytes are (3 bytes outreg, 3 bytes EEPROM) x 4 channels */
+  uint8_t reg_base = 6 * ((uint8_t)channel);
+
+  i2c_dev->read(input_buffer, 24);
+  value =
+      input_buffer[reg_base + 5] + ((0x0F & input_buffer[reg_base + 4]) << 8);
+
+  return value;
+}

--- a/Adafruit_MCP4728.h
+++ b/Adafruit_MCP4728.h
@@ -100,6 +100,9 @@ public:
                  uint16_t channel_c_value, uint16_t channel_d_value);
   bool saveToEEPROM(void);
 
+  uint16_t getChannelValue(MCP4728_channel_t channel);
+  uint16_t getEEPROMValue(MCP4728_channel_t channel);
+
 private:
   bool _init(void);
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MCP4728
-version=1.0.7
+version=1.0.9
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for the MCP4728 sensors in the Adafruit shop


### PR DESCRIPTION
As requested in #3 I implemented `mcp.getChannelValue(MCP4728_CHANNEL_x)` and `mcp.getEEPROMValue(MCP4728_CHANNEL_x)` to be able to read back the current and stored values for each channel.